### PR TITLE
Do not claim copyright for future years yet

### DIFF
--- a/genconsts.py
+++ b/genconsts.py
@@ -28,7 +28,7 @@ Author: %s
   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
   License for the specific language governing permissions and limitations
   under the License.""" % (
-    now.year, ', '.join(['Robert Altnoeder', 'Roland Kammerer', 'Gabor Hernadi', 'Rene Peinthor']))
+    2020, ', '.join(['Robert Altnoeder', 'Roland Kammerer', 'Gabor Hernadi', 'Rene Peinthor']))
 
 
 def get_native_java_type(type_str):

--- a/genproperties.py
+++ b/genproperties.py
@@ -33,7 +33,7 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.""" % (
-    now.year, ', '.join(['Rene Peinthor', 'Gabor Hernadi']))
+    2020, ', '.join(['Rene Peinthor', 'Gabor Hernadi']))
 
 
 class MyPyKey(object):


### PR DESCRIPTION
Do not claim copyright for future years yet.

While working on [reproducible builds](https://reproducible-builds.org/) for [openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds), I found that
without this patch, building `python-linstor-1.1.2`
later would produce different build results:

```diff
+++ new//usr/lib/python3.8/site-packages/linstor/properties.py  2020-06-01 00:00
:00.000000000 +0000
@@ -2,7 +2,7 @@
 This file was autogenerated by genproperties.py

 LINSTOR - management of distributed storage/DRBD9 resources
-Copyright (C) 2017 - 2020  LINBIT HA-Solutions GmbH
+Copyright (C) 2017 - 2035  LINBIT HA-Solutions GmbH
 Author: Rene Peinthor, Gabor Hernadi
```

See also on this topic:
https://stackoverflow.com/questions/2390230/do-copyright-dates-need-to-be-updated